### PR TITLE
feat(version): add npmmirror cdn link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/vue-repl",
-  "version": "1.0.2",
+  "version": "1.1.2",
   "description": "OpenTiny Vue Playground",
   "homepage": "https://opentiny.github.io/tiny-vue-playground/",
   "keywords": [

--- a/src/utils/dependency.ts
+++ b/src/utils/dependency.ts
@@ -14,12 +14,13 @@ export interface Dependency {
 export type Cdn = 'unpkg' | 'jsdelivr' | 'jsdelivr-fastly'
 export const cdn = useLocalStorage('setting-cdn', localStorage.getItem('setting-cdn') || 'https://unpkg.com')
 
-const versionDelimiter = cdn.value.includes('npmmirror') ? '/' : '@'
-const fileDelimiter = cdn.value.includes('npmmirror') ? 'files' : ''
+const isNpmMirror = cdn.value.includes('npmmirror')
+const versionDelimiter = isNpmMirror ? '/' : '@'
+const fileDelimiter = isNpmMirror ? 'files' : ''
 
 export function genCdnLink(pkg: string, version: string | undefined, path: string) {
-  version = version ? `${versionDelimiter}${version}` : ''
-  return `${cdn.value}/${pkg}${version}/${fileDelimiter}${path}`
+  const formattedVersion = version ? `${versionDelimiter}${version}` : ''
+  return `${cdn.value}/${pkg}${formattedVersion}/${fileDelimiter}${path}`
 }
 
 export function genVueLink(version: string) {

--- a/src/utils/dependency.ts
+++ b/src/utils/dependency.ts
@@ -14,9 +14,12 @@ export interface Dependency {
 export type Cdn = 'unpkg' | 'jsdelivr' | 'jsdelivr-fastly'
 export const cdn = useLocalStorage('setting-cdn', localStorage.getItem('setting-cdn') || 'https://unpkg.com')
 
+const versionDelimiter = cdn.value.includes('npmmirror') ? '/' : '@'
+const fileDelimiter = cdn.value.includes('npmmirror') ? 'files' : ''
+
 export function genCdnLink(pkg: string, version: string | undefined, path: string) {
-  version = version ? `@${version}` : ''
-  return `${cdn.value}/${pkg}${version}${path}`
+  version = version ? `${versionDelimiter}${version}` : ''
+  return `${cdn.value}/${pkg}${version}/${fileDelimiter}${path}`
 }
 
 export function genVueLink(version: string) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced CDN link generation to support various CDNs with customizable delimiters.

- **Chores**
  - Updated version of the `@opentiny/vue-repl` package from `1.0.2` to `1.1.2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->