### PR TITLE
feat: 新增刷新按钮

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -49,12 +49,19 @@ const dark = useDark()
 
 // persist state
 watchEffect(() => history.replaceState({}, '', `#${store.serialize()}`))
+
+const replRef = ref<InstanceType<typeof Repl>>()
+
+function reloadPage() {
+  replRef.value?.reload()
+}
 </script>
 
 <template>
   <div v-if="!loading" antialiased>
-    <Header :store="store" />
+    <Header :store="store" @reloadPage="reloadPage" />
     <Repl
+      ref="replRef"
       :theme="dark ? 'dark' : 'light'"
       :store="store"
       :editor="Monaco"

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { reactive, ref } from 'vue'
+import { defineEmits, reactive, ref } from 'vue'
 import type { Ref } from 'vue'
 
 import { Notify, Option as TinyOption, Select as TinySelect } from '@opentiny/vue'
@@ -14,6 +14,12 @@ import { type ReplStore, type VersionKey } from '@/composables/store'
 const { store } = defineProps<{
   store: ReplStore
 }>()
+
+const emit = defineEmits(['reloadPage'])
+
+function reloadPage() {
+  emit('reloadPage')
+}
 
 const dark = useDark()
 const toggleDark = useToggle(dark)
@@ -103,6 +109,9 @@ async function copyLink() {
           <a href="https://github.com/opentiny/tiny-vue-playground/tree/main" target="_blank">
             <GitHub />
           </a>
+        </div>
+        <div flex-1 @click="reloadPage">
+          <GitHub />
         </div>
       </div>
     </div>


### PR DESCRIPTION
由于仓库内使用的是svg而不是opentiny-icon，所以复制了一份 GitHub 图标暂用，如果merge的话管理员可以修改图片

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a reload functionality to refresh the REPL component from the header.
  - Introduced a refresh button in the header with a click event to trigger the reload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->